### PR TITLE
エラー（ $is_water is not defined ）回避

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -14,6 +14,7 @@ var $fdeck_list = {};
 var $next_mapinfo = null;
 var $next_enemy = null;
 var $is_boss = false;
+var $is_water = false;
 var $material = {};
 var $quest_count = 0;
 var $quest_exec_count = 0;


### PR DESCRIPTION
連合艦隊出撃せずに他の種類の出撃をするとエラーが出る
