### PR TITLE
1-6で新規実装された通常艦隊での航空戦マスへの対処

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1538,7 +1538,8 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 	else if (api_name == '/api_req_sortie/battle'
 		|| api_name == '/api_req_combined_battle/battle'
 		|| api_name == '/api_req_combined_battle/battle_water'
-		|| api_name == '/api_req_combined_battle/airbattle') {
+		|| api_name == '/api_req_combined_battle/airbattle'
+		|| api_name == '/api_req_sortie/airbattle') {
 		// 昼戦開始.
 		$battle_count++;
 		$beginhps = null;


### PR DESCRIPTION
1-6で新規実装された通常艦隊での航空戦マスへの対処

単純に後ろに追加しただけなので順番が気になるときは直してください。