### PR TITLE
2016冬イベで実装された空襲マス

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2447,6 +2447,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 	}
 	else if (api_name == '/api_req_sortie/battle'
 		|| api_name == '/api_req_sortie/airbattle'
+		|| api_name == '/api_req_sortie/ld_airbattle'
 		|| api_name == '/api_req_combined_battle/battle'
 		|| api_name == '/api_req_combined_battle/battle_water'
 		|| api_name == '/api_req_combined_battle/airbattle') {


### PR DESCRIPTION
取り急ぎE-1から出てくる通常艦隊向け空襲マスで動作するように

TODO：勝敗判定が異なるため勝敗推定も要修正