### PR TITLE
permissions の不足で動作していなかった

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
 	"description": "艦これの余所見プレイを支援する(cond_checker改造版)",
 	"homepage_url": "http://hkuno9000.github.io/KanColle-YPS/",
 	"permissions": [
-		"storage"
+		"storage",
+		"tabs"
 	],
 	"background": {
 		"scripts": ["background.js"]


### PR DESCRIPTION
一部環境では何故か逆に permissions なしでも動作してしまっているようだが、
background.js から content.js にメッセージングする際の
chrome.tabs.query が動作せず、コールバックに渡される tab が空配列になっていた