### PR TITLE
艦娘解体後艦隊表示修正

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1106,11 +1106,11 @@ function slotitem_delete(slot) {
 	});
 }
 
-function ship_delete(list, keep_slot) {
+function ship_delete(list, keep_slot, remove_ship) {
 	if (!list) return;
 	list.forEach(function(id) {
 		var f_id = $ship_fdeck[id];
-		if (f_id) {
+		if (f_id && remove_ship) {
 			var fleet_list = $fdeck_list[f_id].api_ship;
 			for (var idx in fleet_list) {
 				if (fleet_list[idx] == id) break;
@@ -3006,7 +3006,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		func = function(json) {
 			var dest = decode_postdata_params(request.request.postData.params).api_slot_dest_flag;
 			var ids = decode_postdata_params(request.request.postData.params).api_ship_id;
-			if (ids) ship_delete(/%2C/.test(ids) ? ids.split('%2C') : [ids], dest==0);	// 解体した艦娘を、リストから抜く.
+			if (ids) ship_delete(/%2C/.test(ids) ? ids.split('%2C') : [ids], dest==0, true);	// 解体した艦娘を、リストから抜く.
 			update_material(json.api_data.api_material, $material.destroyship); /// 解体による資材増加を記録する.
 			print_port();
 		};
@@ -3014,7 +3014,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 	else if (api_name == '/api_req_kaisou/powerup') {
 		// 近代化改修.
 		var ids = decode_postdata_params(request.request.postData.params).api_id_items;
-		if (ids) ship_delete(/%2C/.test(ids) ? ids.split('%2C') : [ids]);		// 素材として使った艦娘が持つ装備を、リストから抜く.
+		if (ids) ship_delete(/%2C/.test(ids) ? ids.split('%2C') : [ids], false, true);		// 素材として使った艦娘が持つ装備を、リストから抜く.
 		func = function(json) {
 			var d = json.api_data;
 			if (d.api_ship) delta_update_ship_list([d.api_ship]);

--- a/devtools.js
+++ b/devtools.js
@@ -1109,6 +1109,16 @@ function slotitem_delete(slot) {
 function ship_delete(list, keep_slot) {
 	if (!list) return;
 	list.forEach(function(id) {
+		var f_id = $ship_fdeck[id];
+		if (f_id) {
+			var fleet_list = $fdeck_list[f_id].api_ship;
+			for (var idx in fleet_list) {
+				if (fleet_list[idx] == id) break;
+			}
+			fleet_list.splice(idx, 1);
+			fleet_list.push(-1);
+		}
+		
 		var ship = $ship_list[id];
 		if (ship) {
 			if (!keep_slot) slotitem_delete(ship.slot);


### PR DESCRIPTION
艦隊最後列以外の艦娘を解体した後、その艦娘以降の艦娘は即時(/api_port/port の
update_fdeck_list()まで)反映できなくなります。
解体する時$ship_fdeckから解体された艦娘を除去し、
push_fleet_status()時修正した$ship_fdeckを使って、艦隊を即時反映できるようにしました。