### PR TITLE
Feat: tableではツールチップを行単位で適用する

### DIFF
--- a/content.js
+++ b/content.js
@@ -134,6 +134,9 @@ function tooltip_span(a) {
 function update_tooltip() {
 	for (let e of document.getElementsByClassName('tooltip')) {
 		let pe = e.parentElement;
+		if (pe.tagName == 'TD') {
+			pe = pe.parentElement;
+		}
 		if (/toolmain/.test(pe.className)) continue;
 		pe.className += " toolmain"; // tooltipクラスの親ノードに、toolmainクラスを設定する.
 	}


### PR DESCRIPTION
＞第一列の船名ではなく、第二列のダメージ情報に対してツールチップが出るのがイマイチですが。。。

これの対策です。