### PR TITLE
Fix: 非戦闘マスの判断ミスを修正 (6-3 航空偵察失敗)

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2233,9 +2233,9 @@ function on_next_cell(json) {
 		$battle_log.push(msg);
 		print_next('next loss' + boss_next_name(), msg);
 	}
-	else if (d.api_event_id == 1 || d.api_event_id == 6) {	// 非戦闘マス.
+	else if (d.api_event_id == 1 || d.api_event_id == 6 || d.api_event_id == 7) {	// 非戦闘マス.
 		var msg = area;
-		msg += ':' + event_kind_name(d.api_event_kind);
+		msg += ':' + ((d.api_event_id == 7) ? '航空偵察失敗' : event_kind_name(d.api_event_kind));
 		$battle_log.push(msg);
 		print_next('next skip' + boss_next_name(), msg);
 	}


### PR DESCRIPTION
備考: 航空偵察失敗の場合のJSON field value
d.api_event_id:7, d.api_event_kind:0