### PR TITLE
デイリーパチンコに設置されているリンクへの対策

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/"],
+			"matches": ["http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854*"],
 			"css": ["style-yps.css"],
 			"js": ["content.js"]
 		}


### PR DESCRIPTION
デイリーパチンコに設置されているリンクでは末尾の / がないため今まで動作していなかった