### PR TITLE
Fix: 夕張改二Lv86の時点ではコンバート改装できないのにコンバート改装可能と判定される問題

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -214,6 +214,7 @@ Ship.prototype.can_convert = function() {
 		for (let after = $mst_ship[current.api_aftershipid]; after != null; after = $mst_ship[after.api_aftershipid]) {
 			if (after == current) return true;
 			if (checked[after.api_id]) break;
+			if (after.api_afterlv > this.lv) break;
 			checked[after.api_id] = true;
 		}
 	}


### PR DESCRIPTION
夕張改二/特/乙の3種コンバート対応の can_convert 内でも Lv の比較を行うようにして対応