### PR TITLE
Update: 装甲艇(AB艇)、武装大発

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1425,6 +1425,16 @@ Daihatu.prototype.count_up = function(value) {
 		this.level += value.level;
 		this.sum++;
 		break;
+	case 408:	// 装甲艇(AB艇).
+		this.up += 2;
+		this.level += value.level;
+		this.sum++;
+		break;
+	case 409:	// 武装大発.
+		this.up += 3;
+		this.level += value.level;
+		this.sum++;
+		break;
 	}
 	if (value.ship_id == 487) { // 鬼怒改二.
 		this.up += 5;


### PR DESCRIPTION
2021/02/26 実装の新装備 装甲艇(AB艇)および武装大発による遠征獲得量の増加分を計算に入れる。

特大発とのシナジーについてはないものと判断。
Cf. https://twitter.com/eikagen582/status/1365330006470053895