### PR TITLE
Update: 夜戦カットインの種別追加

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1177,6 +1177,12 @@ function battle_sp_name(a, si) {
 	case 6: return '空母夜襲カットイン';
 	case 7: return '主魚電カットイン';
 	case 8: return '魚見電カットイン';
+	case 9: return '魚魚水カットイン';
+	case 10: return '魚ド水カットイン';
+	case 11: return '主魚電カットイン2';
+	case 12: return '魚見電カットイン2';
+	case 13: return '魚魚水カットイン2';
+	case 14: return '魚ド水カットイン2';
 	case 100: return 'Nelson Touch';
 	case 101: return '長門一斉射';
 	case 102: return '陸奥一斉射';


### PR DESCRIPTION
2021春イベタイミングで追加実装された夜戦カットインの種別を追加

Cf. https://twitter.com/CC_jabberwock/status/1391174067777007621

```
軽くまとめると
夜戦の駆逐カットインにID9~14が追加されて
主魚電(7)　魚電見(8)　魚魚水(9)　魚ド水(10)にそれぞれ2発のパターン11,12,13,14が追加
主魚電はD砲補正が載る(魚電見は不明 )　魚魚水は載らない
複数発動する場合の優先度はよくわからない
```