### PR TITLE
Update: 大発動艇(II号戦車/北アフリカ仕様), 特大発動艇+一式砲戦車 の資源増加量の反映

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1455,6 +1455,16 @@ Daihatu.prototype.count_up = function(value) {
 		this.sum++;
 		break;
 	}
+	case 436:	// 大発動艇(II号戦車/北アフリカ仕様).
+		this.up += 2;
+		this.level += value.level;
+		this.sum++;
+		break;
+	case 449:	// 特大発動艇+一式砲戦車
+		this.up += 2;
+		this.level += value.level;
+		this.sum++;
+		break;
 	if (value.ship_id == 487) { // 鬼怒改二.
 		this.up += 5;
 	}


### PR DESCRIPTION
件名通り。強いていえば、資源増加量も同じ2%で、特大発補正も存在しない点で共通している、 大発動艇(八九式中戦車&陸戦隊) と同じ case にまとめたほうが良いかもしれないくらい？
（とはいえそれを言うと 装甲艇(AB艇) も同様）