### PR TITLE
Fix: li タグが1個しかない ul タグの直後の要素が巻き込まれる問題の修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -133,6 +133,7 @@ function fixup_tooltip() {
 function parse_markdown(a) {
 	var html = "";
 	var li_count = 0;
+	var ul_count = 0;
 	var tr_count = 0;
 	for (var i = 0; i < a.length; ++i) {
 		var s = a[i];
@@ -191,8 +192,8 @@ function parse_markdown(a) {
 									  t = t.replace(/<td>==/g, '<th>'); // "\t==" はヘッダセル.
 									}
 		// リストを<ul>で括る.
-		if (li_count == 1) html += '<ul class="markdown">';
-		if (li_count > 0 && !/^<li>/.test(t)) { li_count = 0; html += "</ul>"; } 
+		if (ul_count == 0 && li_count == 1) { html += '<ul class="markdown">'; ul_count = 1; }
+		if (ul_count > 0 && li_count > 0 && !/^<li>/.test(t)) { li_count = 0; ul_count = 0; html += "</ul>"; } 
 		// テーブルを<table>で括る.
 		if (tr_count == 1) html += '<table class="markdown">';
 		if (tr_count > 0 && !/^<tr>/.test(t)) { tr_count = 0; html += "</table>"; } 
@@ -201,7 +202,7 @@ function parse_markdown(a) {
 		else   html += '<div>' + s + '</div>';
 	}
 	// リスト、テーブルの括り漏れに対処する.
-	if (li_count > 0) { html += "</ul>"; } 
+	if (ul_count > 0 || li_count > 0) { html += "</ul>"; } 
 	if (tr_count > 0) { html += "</table>"; } 
 	return html;
 }


### PR DESCRIPTION
2個以上のliタグがある場合はulの閉じタグ挙動は正常に動いているように見えるが、1個しかない場合、次の要素の開始時に余計なulタグが生成されて入れ子状態になっている模様。ulタグはYPSでは基本的にはネストしないため、ulタグの入れ子は発生しないものと割り切って対処。

・チェック中の任務が2つある場合
<img width="393" height="117" alt="スクリーンショット 2025-10-21 024508" src="https://github.com/user-attachments/assets/fe6260bc-651a-489d-9538-30602957322b" />

・チェック中の任務が1つしかない場合
<img width="332" height="114" alt="スクリーンショット 2025-10-21 024428" src="https://github.com/user-attachments/assets/877d83ae-b262-4d16-819e-1bdaeda490fe" />
