### PR TITLE
Update: 潜水艦に特四式内火艇を積み、特殊な環礁マスに到達した際の特殊攻撃への命名・具体化  / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -1209,6 +1209,7 @@ function battle_sp_name(a, si) {
 	case 200: return '夜間瑞雲カットイン';
 	case 400: return '大和突撃(3隻)';
 	case 401: return '大和突撃(2隻)';
+	case 1000: return '内火艇特殊攻撃';
 	default: return a; // 不明.
 	}
 }


### PR DESCRIPTION
2024春イベで登場した特殊な環礁マスに特四式内火艇(改)を持ち込んだ際に発生する特殊攻撃への名付け。対応 issue は #190 。 「潜水艦内火艇特殊攻撃」にするか迷ったが、水母等、潜水艦以外に積んだ場合にも発生するため、「内火艇特殊攻撃」に。 なお、調べた限りでは運営からはこの攻撃についての言及はなさそう。

今後登場するかは不明だが #190 を close するための PR 。