### PR TITLE
Fix: 遊撃部隊退避時の大破進撃警告バグ #206 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2676,7 +2676,7 @@ function on_next_cell(json) {
 
 /// 護衛退避艦リストに艦IDを追加する. idx = 1..6, 7..12
 function add_ship_escape(idx) {
-	if ($combined_flag) {
+	if ($combined_flag && $battle_deck_id == 1) {
 		if (idx >= 7)
 			$ship_escape[$fdeck_list[2].api_ship[idx-7]] = 1; // 第ニ艦隊から退避.
 		else if (idx >= 1)


### PR DESCRIPTION
#206 で報告のあった遊撃部隊退避時の大破進撃警告バグの修正。
連合艦隊結成中＋遊撃艦隊出撃という状況で発生していた。
出撃中の艦隊IDを見ることで対処。