### PR TITLE
Feat: interruptData のやり取り ＆ ギミック達成を強調表示する

### DIFF
--- a/content.js
+++ b/content.js
@@ -324,6 +324,14 @@ chrome.runtime.onMessage.addListener(function (req) {
 		pop_history();
 		div.innerHTML += parse_markdown(req.appendData);
 	}
+	else if (req.interruptData) {
+		// 下に追加される appendData と異なり目立つ位置に割り込ませる
+		pop_history();
+		var temp = document.createElement('div');
+		temp.classList.add('yps-interrupt');
+		div.insertBefore(temp, document.getElementById(req.interruptData.key));
+		temp.innerHTML = parse_markdown(req.interruptData.value);
+	}
 	else if (req.ship_export_json) {
 		ship_textarea.innerText = req.ship_export_json;
 		slot_textarea.innerText = req.slot_export_json;


### PR DESCRIPTION
ギミック達成の判定が mp3 を拾うことでしか出来ないようだったので

- mp3 のファイル名を見ることで対象となるSEが鳴ったかどうかを判定
- 母港帰還後の特定のタイミングで鳴るものだけを拾うために変数を追加して状態管理
- 直前の画面に追加するのが自然な情報なので interruptData として devtools.js - content.js 間のやり取りを追加

という機能として実装した。

\### よそ見どころかミュートしている環境でもギミック達成を見逃さない

\### 例外的にギミック達成した直後、母港に戻らず画面の更新をかけた新規ログインの場合でも
\### ギミック達成音が鳴るのだが、レアケースすぎるので今のところ対応はしない