### PR TITLE
Fix: Glorious を改装すると未保有艦一覧に出てきてしまう #214 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -477,8 +477,12 @@ function update_mst_ship(list) {
 				before[a] = data.api_id;
 		}
 		const getmes = to_string(data.api_getmes);
-		if (getmes.replace('<br>', '').length > 0) // 未改装の艦種IDにのみ、取得時挨拶文があると想定した判定条件である.
-			begin[data.api_id] = true;
+		if (getmes.replace('<br>', '').length > 0) { // 未改装の艦種IDにのみ、取得時挨拶文があると想定した判定条件である. Glorious系統による例外あり #214
+			if(begin[data.api_id] !== false) {
+				begin[data.api_id] = true;
+			}
+			begin[data.api_aftershipid] = false;
+		}
 	});
 	for (let id in $mst_ship) {
 		let b = before[id];


### PR DESCRIPTION
issue #214 で指摘があったようにGloriousを改装すると未保有艦一覧に出てきてしまう。原因はGlorious(正規空母)（改装二段階目）のapi_getmesに`<br>`以外の文字列が入っていること。 beginによる判定は強力かつ有効なので、api_aftershipidも同時に見て改装後の艦のbeginフラグは落とす・上書きすることにした。

\### Glorious Glorious(正規空母) Glorious改(正規空母) Glorious改(巡洋戦艦)の表記は艦これwikiに準じる 
\### https://wikiwiki.jp/kancolle/Glorious
\### > 宗谷と同様艦名は全く変化せず艦種表記だけが変わる。改についても艦種表記だけが異なる2種類が存在する。 
\### > 当wikiでは宗谷に倣い、改装後のページはそれぞれGlorious(正規空母)、Glorious改(正規空母)、Glorious改(巡洋戦艦)と艦種名を付けて区別している。