### PR TITLE
Feat: 達成した任務に選択報酬があるときアイテム類の表を提示する(useitem + furniture + ダブり艦の保持を下敷きとして)

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2648,7 +2648,7 @@ function build_selection_support_table_md(reward_list, title, subtitle, dom_id) 
 	var cols = 1;
 
 	for(var idx in reward_list) {
-		if(cols < reward_list[idx].length) {
+		if(cols <= reward_list[idx].length) {
 			cols = reward_list[idx].length + 1; // 報酬選択肢の最大数+1
 		}
 	}


### PR DESCRIPTION
require_info ならびに useitem で得られる useitem の情報を他の処理で参照しやすいように内部的に保持しておく

\### #173 を実現するなら必要そうなので

mst_furniture 、furniture の保持も追加

艦種IDで引ける艦の保持方法( \$all_ship_id_list )も追加

以上、useitem、 furniture、 \$all_ship_id_list を内部的に保持した実装を下敷きとして。

#173 でアイデアの提示された「任務報酬アイテム選択時に、保持済みアイテム表を表示する」機能を実装。選択報酬のある任務を達成したとき、任務一覧の上部に割り込むかたちで選択報酬と手持ちの情報を提示する。
艦船(11)、装備(12)、アイテム(13)、家具(14)についてはおおよそ問題ないと思われるが、それ以外の類別だった場合や装備運用枠のような特殊なものが追加されたときなど、例外的なデータだった場合はこれでもかと書いた「不明な～」シリーズが表示される。例示4種対応ができていれば実用的には問題ないと判断して投入。やや実験的な実装である。

\### 個人的な好みもあって detail の中に表を隠すかたちで実装したが、隠さないほうが使い勝手がよいかもしれない
\### フラットなかたちで書き直すか、detail を open にできる新機能を追加するかは考慮のしどころ