### PR TITLE
Feat: 装甲破砕の可視化 / Update devtools.js + Update: 基地空襲の表記を調整 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2576,17 +2576,17 @@ function on_next_cell(json) {
 	var area = d.api_maparea_id + '-' + d.api_mapinfo_no + '-' + d.api_no;
 	$next_mapinfo = $mst_mapinfo[d.api_maparea_id * 10 + d.api_mapinfo_no];
 	$is_next = (d.api_next > 0);
-	if (d.api_event_id == 5) {
-		area += '(boss)';
-		$is_boss = true;
-	}
 	var seiku_notify = ''; // print_next に紛れ込ませたいので事前に判定: 戦闘マス・非戦闘マスでの発生を確認
 	if (d.api_destruction_battle) { // 基地空襲の発生
 		var seiku = seiku_name(d.api_destruction_battle.api_air_base_attack.api_stage1.api_disp_seiku);
 		$battle_log.push(area + '(基地空襲):' + seiku);
-		seiku_notify = seiku.match(/優勢|確保/ui) ?
+		seiku_notify = seiku.match(/優勢|確保/ui) && !$next_mapinfo.yps_cleared ?
 			('### 基地空襲の発生:@!!' + seiku + '!!@') :
 			('### 基地空襲の発生:' + seiku);
+	}
+	if (d.api_event_id == 5) {
+		area += '(boss)';
+		$is_boss = true;
 	}
 	if (g) {	// 資源マス.
 		var msg = area;


### PR DESCRIPTION
装甲破砕については api_xal01 フラグの有無による装甲破砕の表示を追加

基地空襲の更新は以下2点
- イベントマップのクリア後は基地空襲の優勢・確保を注視しなくても良いので赤表示をやめる
- 「61-5-4(boss)(基地空襲)」のような(boss)と(基地空襲)がダブる表示はダサいのでやめる

両者に共通して api_cleared -> yps_cleared によるクリア状態の保持を利用