### PR TITLE
Fix: is_current_sortie_map の判定修正 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2321,7 +2321,7 @@ function is_current_sortie_map(area, no) {
 	if(!no) {
 		no = '*';
 	}
-	if(no.match(/^>\d$/ui) ) {
+	if(/^>\d$/.test(no)) {
 		var start = no.replace('>', '');
 		nums = nums.slice(start);
 	} else if(Array.isArray(no) ){


### PR DESCRIPTION
no が文字列でなかった場合に止まるため match から test へと置き換えた
具体的には is_current_sortie_map(4,4) is_current_sortie_map(1, 5) is_current_sortie_map(5,2) の呼び出しへの対応