### PR TITLE
Fix: 選択報酬に艦娘が含まれていた場合のエラーを修正 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2769,7 +2769,7 @@ function get_reward_item_name_count_of_mine(mst_id, kind) {
 	if(kind == 11) {
 		var shiplist = $all_ship_id_list[mst_id];
 		return shiplist ?
-			shiplist_names(shiplist) :
+			shiplist_names(shiplist.map(function(id) { return $ship_list[id]; })) :
 			get_reward_item_name(mst_id, kind) + '(未保有)';
 	} else if(kind == 12) {
 		return slotitem_levellist(mst_id).join(',');


### PR DESCRIPTION
任務の選択報酬に艦娘が含まれていた場合、名前を取り出す処理に適切でない配列を渡しているミスがあったため、エラーを起こしていた箇所を修正

\### 2026/3/13 メンテで追加された 1028:(単)【WD限定任務】軽空母、出撃！2026 で発覚