### PR TITLE
Fix: 13周年メンテで追加された任務で選択報酬表示がおかしいものを修正 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2829,15 +2829,30 @@ function get_reward_item_name_count_of_mine(mst_id, kind) {
 function translate_reward_info_to_item_names(info) {
 	// info: { api_no, api_kind, api_mst_id, api_slotitem_level, api_count }
 	var names = {};
+	var mst_id = adjust_reward_info_mst_id_if_blank_mst_useitem(info.api_mst_id, info.api_kind);
 	names.kind = get_kind_name(info.api_kind);
-	names.item_name = get_reward_item_name(info.api_mst_id, info.api_kind, info.api_slotitem_level);
-	names.item_count = info.api_mst_id > 900 ?
-		info.api_mst_id - 900 :  // 装備運用枠は扱いが特殊: api_count は常に1 mst_id=901 は +1 902 は +2 ... と900番台の下位の数値分だけ保有枠が増加する
-		(Number.isInteger(get_mst_id_to_rate(info.api_mst_id)) ?
-		get_mst_id_to_rate(info.api_mst_id) :
+	names.item_name = get_reward_item_name(mst_id, info.api_kind, info.api_slotitem_level);
+	names.item_count = mst_id > 900 ?
+		mst_id - 900 :  // 装備運用枠は扱いが特殊: api_count は常に1 mst_id=901 は +1 902 は +2 ... と900番台の下位の数値分だけ保有枠が増加する
+		(Number.isInteger(get_mst_id_to_rate(mst_id)) ?
+		get_mst_id_to_rate(mst_id) :
 		info.api_count);
-	names.item_name_count_of_mine = get_reward_item_name_count_of_mine(info.api_mst_id, info.api_kind);
+	names.item_name_count_of_mine = get_reward_item_name_count_of_mine(mst_id, info.api_kind);
 	return names;
+}
+
+function adjust_reward_info_mst_id_if_blank_mst_useitem(mst_id, kind) {
+	if(kind != 13) {
+		return mst_id;
+	}
+	if(get_reward_item_name(mst_id, kind) != '') {
+		return mst_id;
+	}
+	switch(mst_id) {
+	// api_material の並びからの混同による例外的 mst_id と思われるが汎用的な対処が可能か判断がつかないので一旦ベタ書きで対処
+	case 5: return 2; // 高速建造材 
+	}
+	return mst_id;
 }
 
 function build_selection_support_table_md(reward_list, title, subtitle, dom_id) {


### PR DESCRIPTION
2026年4月23日に実施された13周年アップデートのメンテナンスによって追加された任務「449:(単)【13周年記念任務】13周年観艦式」の選択報酬に高速建造材が含まれているが、この名称表示が落ちていたので修正

表示はこうなっていた
> 449:(単)【13周年記念任務】13周年観艦式
> 任務449	選択報酬1	選択報酬2	選択報酬3
> 選択肢	燃料x2026	ボーキサイトx2026	開発資材x13
> 手持ち	燃料x190384	ボーキサイトx254192	開発資材x64
> 選択肢	x100	12.7cm単装高角砲改二x1	勲章x3
> 手持ち	x0	12.7cm単装高角砲改二 x1,★+4 x1,★+6 x1	勲章x63

該当のJSONは以下
```
            {
                "api_no": 449,
                "api_category": 4,
                "api_type": 4,
                "api_label_type": 1,
                "api_state": 3,
                "api_title": "【13周年記念任務】13周年観艦式",
                "api_detail": "【13周年記念観艦式】艦隊13周年を祝して、祝賀記念の「観艦式」を挙行せよ！",
                "api_voice_id": 0,
                "api_select_rewards": [
                    [
                        {
                            "api_no": 1,
                            "api_kind": 13,
                            "api_mst_id": 31,
                            "api_count": 2026
                        },
                        {
                            "api_no": 2,
                            "api_kind": 13,
                            "api_mst_id": 34,
                            "api_count": 2026
                        },
                        {
                            "api_no": 3,
                            "api_kind": 13,
                            "api_mst_id": 3,
                            "api_count": 13
                        }
                    ],
                    [
                        {
                            "api_no": 1,
                            "api_kind": 13,
                            "api_mst_id": 5,
                            "api_count": 100
                        },
                        {
                            "api_no": 2,
                            "api_kind": 12,
                            "api_mst_id": 379,
                            "api_count": 1
                        },
                        {
                            "api_no": 3,
                            "api_kind": 13,
                            "api_mst_id": 57,
                            "api_count": 3
                        }
                    ]
                ],
                "api_get_material": [
                    0,
                    0,
                    2026,
                    0
                ],
                "api_bonus_flag": 1,
                "api_progress_flag": 0,
                "api_invalid_flag": 0
            },
```

`getData` の `api_mst_useitem` からすると `"api_mst_id": 2,` が期待されるのだが、実際のデータでは `"api_mst_id": 5,` が入っている。