### PR TITLE
Update: 新通常海域5-6も複数ゲージ / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -4772,8 +4772,8 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 					var ty = (evm && evm.api_gauge_type) ? evm.api_gauge_type : data.api_gauge_type;
 					var now = evm ? evm.api_now_maphp : data.api_defeat_count;
 					var max = evm ? evm.api_max_maphp : data.api_required_defeat_count;
-					// 通常海域では 7-2 7-3 7-5 が複数ゲージだがデータ上区別できないので決め打ち
-					var gn = ((evm && evm.api_state == 1) || data.api_id == 72 || data.api_id == 73 || data.api_id == 75) ? data.api_gauge_num : 0;
+					// 通常海域では 5-6 7-2 7-3 7-5 が複数ゲージだがデータ上区別できないので決め打ち
+					var gn = ((evm && evm.api_state == 1) || data.api_id == 56 || data.api_id == 72 || data.api_id == 73 || data.api_id == 75) ? data.api_gauge_num : 0;
 					mst.yps_opt_name = (gn ? gn + 'ゲージ目 ' : '') + (ty == 3 ? 'TP' : ty == 2 ? 'HP' : '') + fraction_percent_name(now, max);
 					uncleared.push('* ' + map_name(mst));
 				}


### PR DESCRIPTION
2026/05/29 メンテ後に追加された新通常海域 5-6 も複数ゲージのマップのため対応を追加

\# 雑感等
\# 分岐点係数は軽く調べた範囲ではまだ出てきていない様子
\# 通常海域・イベント海域で普段はゲージの進捗の増減が逆なのだが
\# 通常海域初の輸送ゲージが出てきたため、ここの齟齬が気になるようになった
\# TPだけ見せ方を変えるとか？