### PR TITLE
Update: 通常海域でのTP輸送のゲージ増減の表示を補正 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -4774,6 +4774,10 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 					var max = evm ? evm.api_max_maphp : data.api_required_defeat_count;
 					// 通常海域では 7-2 7-3 7-5 が複数ゲージだがデータ上区別できないので決め打ち
 					var gn = ((evm && evm.api_state == 1) || data.api_id == 72 || data.api_id == 73 || data.api_id == 75) ? data.api_gauge_num : 0;
+					// 通常海域のTPの増減の向きを補正(例 5-6-1)
+					if(!evm && ty == 3) {
+						now = max - now;
+					}
 					mst.yps_opt_name = (gn ? gn + 'ゲージ目 ' : '') + (ty == 3 ? 'TP' : ty == 2 ? 'HP' : '') + fraction_percent_name(now, max);
 					uncleared.push('* ' + map_name(mst));
 				}


### PR DESCRIPTION
新海域5-6の1ゲージ目に通常海域初となるTP輸送が実装されたが、 api_required_defeat_count api_defeat_count の扱い（カウントアップ）がイベント海域における api_max_maphp api_now_maphp （カウントダウン）と異なることから、ゲージ増減の向きがゲーム上の見た目と異なるので補正する

参考情報として、輸送成功時の api_now_hp api_sub_value はカウントダウン方向でデータが返ってくるため、通常海域でも補正は不要