### PR TITLE
Fix: 道中にドロップ艦があると海域突破報酬の選択肢を確認できない / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -2400,7 +2400,7 @@ function slotitem_levellist(mstid) {
 	var basename = slotitem_name(mstid);
 	for (var id in $slotitem_list) {
 		var value = $slotitem_list[id];
-		if (value.item_id == mstid) {
+		if (value && value.item_id == mstid) {
 			var name = slotitem_name(value.item_id, value.level, value.alv);
 			if (count[name] == null)
 				count[name] = 1;


### PR DESCRIPTION
ドロップ艦があった場合にダミー装備として $slotitem_list に null が入るためエラーになる

nullが入るのは https://github.com/hkuno9000/KanColle-YPS/blob/646e28e05f6f849222efebf42256ddcd92e7e5f0/devtools.js#L457