### PR TITLE
Fix: 連合艦隊＋遊撃部隊両運用すると戦闘詳報がおかしくなる問題 / Update devtools.js

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -3307,7 +3307,7 @@ function ship_name_lv(idx, ae, ff) {
 			if (f.api_ship_lv) s +=    'Lv' + f.api_ship_lv[i];
 			return s;
 		}
-		if ($combined_flag && idx >= 6) {
+		if ($combined_flag && $battle_deck_id == 1 && idx >= 6) {
 			let s = '(第二艦隊' + (idx-6+1) + ')';
 			if ($debug_battle_json) return s + $debug_ship_names[idx];
 			let fdeck = $fdeck_list[2];


### PR DESCRIPTION
#245 の通り、連合艦隊を結成した状態にして遊撃部隊で出撃すると、戦闘詳報に遊撃部隊7番艦の代わりに連合第二艦隊の旗艦の情報が紛れ込む問題への対応