### PR TITLE
Feature: 遠征帰投・cond回復・入渠完了のデスクトップ通知機能

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,61 @@
 chrome.runtime.onMessage.addListener(function (req) {
+	if (req && req.alarm) {
+		if (req.alarm.action === 'set') {
+			if (req.alarm.data) {
+				var item = {};
+				item['alarm_' + req.alarm.name] = req.alarm.data;
+				chrome.storage.local.set(item, function () {
+					chrome.alarms.create(req.alarm.name, { when: req.alarm.when });
+				});
+			} else {
+				chrome.alarms.create(req.alarm.name, { when: req.alarm.when });
+			}
+		} else if (req.alarm.action === 'clear') {
+			chrome.alarms.clear(req.alarm.name);
+			chrome.storage.local.remove('alarm_' + req.alarm.name);
+		}
+		return;
+	}
+
 	chrome.tabs.query({url:[
-			'https://play.games.dmm.com/game/kancolle'
+			'https://play.games.dmm.com/game/kancolle',
+			'https://play.games.dmm.com/game/kancolle/*'
 		]}, function (tab) {
-		chrome.tabs.sendMessage(tab[0].id, req);
+		if (tab && tab.length > 0 && tab[0].id) {
+			chrome.tabs.sendMessage(tab[0].id, req);
+		}
 	});
+});
+
+chrome.alarms.onAlarm.addListener(function (alarm) {
+	var key = 'alarm_' + alarm.name;
+	chrome.storage.local.get(key, function (res) {
+		var data = res[key] || {};
+		chrome.notifications.create(alarm.name + '_' + Date.now(), {
+			type: 'basic',
+			iconUrl: 'icons/icon128.png',
+			title: data.title || 'KanColle-YPS',
+			message: data.message || '時間になりました。',
+			priority: 0
+		});
+		chrome.storage.local.remove(key);
+	});
+});
+
+chrome.notifications.onClicked.addListener(function (notificationId) {
+	chrome.tabs.query({
+		url: [
+			'https://play.games.dmm.com/game/kancolle',
+			'https://play.games.dmm.com/game/kancolle/*'
+		]
+	}, function (tabs) {
+		if (tabs && tabs.length > 0) {
+			var tab = tabs[0];
+			chrome.tabs.update(tab.id, { active: true });
+			if (tab.windowId) {
+				chrome.windows.update(tab.windowId, { focused: true });
+			}
+		}
+	});
+	chrome.notifications.clear(notificationId);
 });

--- a/background.js
+++ b/background.js
@@ -29,7 +29,11 @@ chrome.runtime.onMessage.addListener(function (req) {
 
 chrome.alarms.onAlarm.addListener(function (alarm) {
 	var key = 'alarm_' + alarm.name;
-	chrome.storage.local.get(key, function (res) {
+	chrome.storage.local.get(['yps_notification_enabled', key], function (res) {
+		if (!res || !res.yps_notification_enabled) {
+			chrome.storage.local.remove(key);
+			return;
+		}
 		var data = res[key] || {};
 		chrome.notifications.create(alarm.name + '_' + Date.now(), {
 			type: 'basic',

--- a/content.js
+++ b/content.js
@@ -308,6 +308,39 @@ function copy_button() {
 		;
 }
 
+var $notification_enabled = false;
+chrome.storage.local.get('yps_notification_enabled', function(res) {
+	if (res && typeof res.yps_notification_enabled === 'boolean') {
+		$notification_enabled = res.yps_notification_enabled;
+	}
+	var btn = document.getElementById('YPS_notification');
+	if (btn) {
+		btn.value = $notification_enabled ? '通知: ON' : '通知: OFF';
+	}
+});
+
+if (chrome.storage.onChanged) {
+	chrome.storage.onChanged.addListener(function(changes, area) {
+		if (area === 'local' && changes.yps_notification_enabled) {
+			$notification_enabled = !!changes.yps_notification_enabled.newValue;
+			var btn = document.getElementById('YPS_notification');
+			if (btn) {
+				btn.value = $notification_enabled ? '通知: ON' : '通知: OFF';
+			}
+		}
+	});
+}
+
+function notification_button() {
+	$button_onclick["YPS_notification"] = function() {
+		$notification_enabled = !$notification_enabled;
+		this.value = $notification_enabled ? '通知: ON' : '通知: OFF';
+		chrome.storage.local.set({ 'yps_notification_enabled': $notification_enabled });
+	};
+	var label = $notification_enabled ? '通知: ON' : '通知: OFF';
+	return ' <input id="YPS_notification" type="button" value="' + label + '"/>';
+}
+
 function version_banner() {
 	return ' <a href="' + home_url + '" target="KanColle-YPS-website" id="YPS_go_help">KanColle-YPS ' + ver_name + '</a>';
 }
@@ -319,7 +352,7 @@ chrome.runtime.onMessage.addListener(function (req) {
 	if (!div.parentNode) document.body.replaceChild(div, hst); // 履歴表示を中断する.
 	if (req instanceof Array) {
 		div.innerHTML = parse_markdown(req);
-		navi.innerHTML = all_close_button() + history_buttons() + version_banner() + "<br/>" + copy_button();
+		navi.innerHTML = all_close_button() + history_buttons() + notification_button() + version_banner() + "<br/>" + copy_button();
 	}
 	else if (req.appendData) {
 		pop_history();

--- a/content.js
+++ b/content.js
@@ -352,7 +352,9 @@ chrome.runtime.onMessage.addListener(function (req) {
 	if (!div.parentNode) document.body.replaceChild(div, hst); // 履歴表示を中断する.
 	if (req instanceof Array) {
 		div.innerHTML = parse_markdown(req);
-		navi.innerHTML = all_close_button() + history_buttons() + notification_button() + version_banner() + "<br/>" + copy_button();
+		navi.innerHTML = all_close_button() + history_buttons() + version_banner() + "<br/>"
+			+ copy_button() + "<br/>"
+			+ notification_button();
 	}
 	else if (req.appendData) {
 		pop_history();

--- a/devtools.js
+++ b/devtools.js
@@ -24,10 +24,35 @@ var $quest_list		= load_storage('quest_list');
 var $air_base		= load_storage('air_base', []); // for noro6/kc-web
 
 var NotificationManager = {
+	enabled: false,
 	_cache: {},
 	_fleet_cond_timers: {},
 	_airbase_timers: {},
+	init: function() {
+		var self = this;
+		if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+			chrome.storage.local.get('yps_notification_enabled', function(res) {
+				self.enabled = !!(res && res.yps_notification_enabled);
+				if (self.enabled) {
+					self.syncAll();
+				}
+			});
+			if (chrome.storage.onChanged) {
+				chrome.storage.onChanged.addListener(function(changes, area) {
+					if (area === 'local' && changes.yps_notification_enabled) {
+						self.enabled = !!changes.yps_notification_enabled.newValue;
+						if (self.enabled) {
+							self.syncAll();
+						} else {
+							self.clearAll();
+						}
+					}
+				});
+			}
+		}
+	},
 	setAlarm: function(name, when, title, message) {
+		if (!this.enabled) return;
 		if (when <= Date.now()) {
 			this.clearAlarm(name);
 			return;
@@ -57,7 +82,21 @@ var NotificationManager = {
 			});
 		}
 	},
+	clearAll: function() {
+		for (var key in this._cache) {
+			chrome.runtime.sendMessage({
+				alarm: {
+					action: 'clear',
+					name: key
+				}
+			});
+		}
+		this._cache = {};
+		this._fleet_cond_timers = {};
+		this._airbase_timers = {};
+	},
 	syncAll: function() {
+		if (!this.enabled) return;
 		this.syncMissionsAndCond();
 		this.syncNdocks();
 		this.syncAirBase();
@@ -228,6 +267,7 @@ var NotificationManager = {
 		});
 	}
 };
+NotificationManager.init();
 var $debug_battle_json = null;
 var $debug_ship_names = [];
 var $debug_api_name = '';

--- a/devtools.js
+++ b/devtools.js
@@ -22,6 +22,186 @@ var $quest_clear	= load_quest_clear();
 var $logbook		= load_storage('logbook', []);
 var $quest_list		= load_storage('quest_list');
 var $air_base		= load_storage('air_base', []); // for noro6/kc-web
+
+var NotificationManager = {
+	_cache: {},
+	_fleet_cond_timers: {},
+	_airbase_timers: {},
+	setAlarm: function(name, when, title, message) {
+		if (when <= Date.now()) {
+			this.clearAlarm(name);
+			return;
+		}
+		var prev = this._cache[name];
+		if (prev && prev.when === when && prev.title === title && prev.message === message) {
+			return; // 変更なしのためスキップ
+		}
+		this._cache[name] = { when: when, title: title, message: message };
+		chrome.runtime.sendMessage({
+			alarm: {
+				action: 'set',
+				name: name,
+				when: when,
+				data: { title: title, message: message }
+			}
+		});
+	},
+	clearAlarm: function(name) {
+		if (this._cache[name]) {
+			delete this._cache[name];
+			chrome.runtime.sendMessage({
+				alarm: {
+					action: 'clear',
+					name: name
+				}
+			});
+		}
+	},
+	syncAll: function() {
+		this.syncMissionsAndCond();
+		this.syncNdocks();
+		this.syncAirBase();
+	},
+	syncMissionsAndCond: function() {
+		if (!$fdeck_list) return;
+		var nowTime = ($pcDateTime ? $pcDateTime.getTime() : Date.now());
+		for (var f_id = 1; f_id <= 4; ++f_id) {
+			var deck = $fdeck_list[f_id];
+			if (!deck) {
+				delete this._fleet_cond_timers[f_id];
+				this.clearAlarm('mission_' + f_id);
+				this.clearAlarm('cond_' + f_id);
+				continue;
+			}
+			var mission_end = (deck.api_mission && deck.api_mission[2]) ? deck.api_mission[2] : 0;
+			if (mission_end > 0) {
+				var id = deck.api_mission[1];
+				var m_name = ($mst_mission && $mst_mission[id]) ? $mst_mission[id].api_name : ('遠征' + id);
+				this.setAlarm('mission_' + f_id, mission_end, '遠征帰投', '第' + f_id + '艦隊（' + m_name + '）が遠征から帰投しました。');
+				delete this._fleet_cond_timers[f_id];
+				this.clearAlarm('cond_' + f_id);
+			} else {
+				this.clearAlarm('mission_' + f_id);
+				var is_sortie = false;
+				if ($battle_deck_id > 0) {
+					if (deck.api_id == $battle_deck_id) {
+						is_sortie = true;
+					} else if ($combined_flag && ($battle_deck_id == 1 || $battle_deck_id == 2) && (deck.api_id == 1 || deck.api_id == 2)) {
+						is_sortie = true;
+					}
+				}
+				if (is_sortie) {
+					delete this._fleet_cond_timers[f_id];
+					this.clearAlarm('cond_' + f_id);
+				} else {
+					var min_cond = 49;
+					if (deck.api_ship && $ship_list) {
+						for (var i = 0; i < deck.api_ship.length; ++i) {
+							var s_id = deck.api_ship[i];
+							if (!s_id || s_id == -1) continue;
+							if ($ndock_list && $ndock_list[s_id]) continue; // 入渠中の艦娘はcond回復判定から除外
+							var s = $ship_list[s_id];
+							if (s && s.c_cond < min_cond) {
+								min_cond = s.c_cond;
+							}
+						}
+					}
+					var ship_sig = (deck.api_ship || []).join(',');
+					if (min_cond < 49) {
+						var cached = this._fleet_cond_timers[f_id];
+						if (cached && cached.ship_sig !== ship_sig) {
+							delete this._fleet_cond_timers[f_id];
+							cached = null;
+						}
+
+						if (cached) {
+							if (min_cond < cached.min_cond) {
+								// 疲労悪化時は新しい目標時刻で再計算
+								var need_steps = Math.ceil((49 - min_cond) / 3);
+								var targetTime = nowTime + (need_steps * 3 * 60 * 1000);
+								this._fleet_cond_timers[f_id] = { ship_sig: ship_sig, min_cond: min_cond, when: targetTime, notified: false };
+								this.setAlarm('cond_' + f_id, targetTime, 'cond回復', '第' + f_id + '艦隊（' + deck.api_name + '）のcond値が回復しました。');
+							} else if (cached.when > nowTime) {
+								// 回復進行中または同一condでタイマー未満了：当初の目標時刻を維持（Timer Drift防止）
+								cached.min_cond = min_cond;
+								this.setAlarm('cond_' + f_id, cached.when, 'cond回復', '第' + f_id + '艦隊（' + deck.api_name + '）のcond値が回復しました。');
+							} else {
+								// 満了後かつ疲労悪化なし：ゴースト再セットを防止
+								cached.min_cond = min_cond;
+								cached.notified = true;
+								this.clearAlarm('cond_' + f_id);
+							}
+						} else {
+							// 新規または編成変更時
+							var need_steps = Math.ceil((49 - min_cond) / 3);
+							var targetTime = nowTime + (need_steps * 3 * 60 * 1000);
+							this._fleet_cond_timers[f_id] = { ship_sig: ship_sig, min_cond: min_cond, when: targetTime, notified: false };
+							this.setAlarm('cond_' + f_id, targetTime, 'cond回復', '第' + f_id + '艦隊（' + deck.api_name + '）のcond値が回復しました。');
+						}
+					} else {
+						delete this._fleet_cond_timers[f_id];
+						this.clearAlarm('cond_' + f_id);
+					}
+				}
+			}
+		}
+	},
+	syncNdocks: function() {
+		var active_docks = {};
+		if ($ndock_list) {
+			for (var ship_id in $ndock_list) {
+				var d = $ndock_list[ship_id];
+				if (d && d.api_complete_time > 0 && d.api_id) {
+					active_docks[d.api_id] = d;
+				}
+			}
+		}
+		for (var dock_id = 1; dock_id <= 4; ++dock_id) {
+			var d = active_docks[dock_id];
+			if (d) {
+				var ship = ($ship_list && d.api_ship_id) ? $ship_list[d.api_ship_id] : null;
+				var ship_name_str = (ship && $mst_ship) ? ship_name(ship.ship_id) : '艦娘';
+				this.setAlarm('ndock_' + dock_id, d.api_complete_time, '入渠完了', '第' + dock_id + 'ドック（' + ship_name_str + '）の入渠が完了しました。');
+			} else {
+				this.clearAlarm('ndock_' + dock_id);
+			}
+		}
+	},
+	syncAirBase: function() {
+		if (!$air_base || !Array.isArray($air_base)) return;
+		var self = this;
+		var nowTime = ($pcDateTime ? $pcDateTime.getTime() : Date.now());
+		$air_base.forEach(function(data) {
+			if (!data || !data.api_area_id || !data.api_rid) return;
+			var plane_info = data.api_plane_info;
+			var max_ab_cond = 1;
+			if (plane_info && Array.isArray(plane_info)) {
+				for (var j = 0; j < plane_info.length; j++) {
+					if (plane_info[j].api_state > 0 && plane_info[j].api_cond > max_ab_cond) {
+						max_ab_cond = plane_info[j].api_cond;
+					}
+				}
+			}
+			var ab_alarm_id = 'airbase_cond_' + data.api_area_id + '_' + data.api_rid;
+			var ab_name = get_maparea_name(data.api_area_id) + ' 第' + data.api_rid + '基地航空隊';
+			if (max_ab_cond >= 2) {
+				var cached = self._airbase_timers[ab_alarm_id];
+				var targetTime;
+				if (cached && cached.cond === max_ab_cond && cached.when > nowTime) {
+					targetTime = cached.when; // 既存の疲労回復予定時刻を維持（リセット防止）
+				} else {
+					var duration = (max_ab_cond === 3 ? 30 : 15) * 60 * 1000;
+					targetTime = nowTime + duration;
+					self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime };
+				}
+				self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
+			} else {
+				delete self._airbase_timers[ab_alarm_id];
+				self.clearAlarm(ab_alarm_id);
+			}
+		});
+	}
+};
 var $debug_battle_json = null;
 var $debug_ship_names = [];
 var $debug_api_name = '';
@@ -1409,7 +1589,7 @@ function map_rank_name(a) {
 
 function get_maparea_name(id) {
 	if (id >= 30) return "期間限定海域";	// 2018.12イベントでは, $mst_maparea[] にはイベント海域名のかわりにダミー文字列が入っている.
-	return $mst_maparea[id];
+	return ($mst_maparea && $mst_maparea[id]) ? $mst_maparea[id] : ('海域' + id);
 }
 
 function get_air_base_action_name(kind) {
@@ -2700,8 +2880,10 @@ function push_all_fleets(req) {
 			var ms = d.getTime() - $pcDateTime.getTime();
 			var rest = ms > 0 ? '残' + msec_name(ms) : '終了';
 			var id = deck.api_mission[1];
-			req.push('遠征' + $mst_mission[id].api_disp_no + ' ' + $mst_mission[id].api_name + ': ' + d.toLocaleString() + '(' + rest + ')');
-			$last_mission[f_id] = '前回遠征: 遠征' + $mst_mission[id].api_disp_no + ' ' + $mst_mission[id].api_name; // 支援遠征では /api_req_mission/result が来ないので、ここで事前更新しておく.
+			var m_name = ($mst_mission && $mst_mission[id]) ? $mst_mission[id].api_name : ('遠征' + id);
+			var m_disp = ($mst_mission && $mst_mission[id]) ? $mst_mission[id].api_disp_no : '';
+			req.push('遠征' + m_disp + ' ' + m_name + ': ' + d.toLocaleString() + '(' + rest + ')');
+			$last_mission[f_id] = '前回遠征: 遠征' + m_disp + ' ' + m_name; // 支援遠征では /api_req_mission/result が来ないので、ここで事前更新しておく.
 			$current_mission[f_id] = id;
 		}
 		else if (deck.api_id == $battle_deck_id) {
@@ -4467,6 +4649,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 			var deck = json.api_data;
 			$fdeck_list[id] = deck;
 			update_fdeck_list($fdeck_list); // 編成結果を $ship_fdeck に反映する.
+			NotificationManager.syncAll();
 			print_port();
 		};
 	}
@@ -4474,6 +4657,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		// 連合艦隊編成・解除.
 		func = function(json) {
 			$combined_flag = decode_postdata_params(request.request.postData.params).api_combined_type;	// 0:解除, 1:機動部隊, 2:水上部隊, 3:輸送護衛部隊.
+			NotificationManager.syncAll();
 			print_port();
 		};
 	}
@@ -4516,6 +4700,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 			}
 		}
 		update_fdeck_list($fdeck_list); // 編成結果を $ship_fdeck に反映する.
+		NotificationManager.syncAll();
 		print_port();
 	}
 	else if (api_name == '/api_req_hensei/lock') {
@@ -4647,6 +4832,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		func = function(json) { // 入渠状況を更新する.
 			update_ndock_complete();
 			update_ndock_list(json.api_data);
+			NotificationManager.syncAll();
 			if ($do_print_port_on_ndock) {
 				$do_print_port_on_ndock = false;
 				print_port();
@@ -4668,6 +4854,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		inc_quest_progress(503); // 艦隊大整備！任務中: ５回なら任務状態を達成(3)に変更する.
 		if (params.api_highspeed != 0) {
 			ship.highspeed_repair();	// 母港パケットで一斉更新されるまで対象艦の修復完了が反映されないので、自前で反映する.
+			NotificationManager.syncAll();
 			print_port();	// 高速修復を使った場合は /api_get_member/ndock パケットが来ないので、ここで print_port() を行う.
 		}
 		else {
@@ -4685,6 +4872,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		var now = $material.now.concat();
 		--now[5];	// 高速修復材(バケツ).
 		update_material(now, $material.ndock);
+		NotificationManager.syncAll();
 		print_port();
 	}
 	else if (api_name == '/api_req_kousyou/createship_speedchange') {
@@ -4722,7 +4910,8 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 				$wait_gimmick_interruption = 5; // API呼び出し5回分ギミック達成判定を追う
 				$event_object = json.api_data.api_event_object;
 			}
-			else {
+			NotificationManager.syncAll();
+			if (!$do_print_port_on_slot_item) {
 				print_port();
 			}
 		};
@@ -4740,6 +4929,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		func = function(json) { // 保有艦、艦隊一覧を更新してcond表示する.
 			delta_update_ship_list(json.api_data); // 間宮伊良湖では全艦、月間任務クリアで差分[1]のみ. スロット装備減少のみで保有艦の増減は無いので常に差分更新でOK.
 			update_fdeck_list(json.api_data_deck);
+			NotificationManager.syncAll();
 			print_port();
 		};
 	}
@@ -4752,6 +4942,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 			else
 				update_ship_list(d.api_ship_data);
 			update_fdeck_list(d.api_deck_data);
+			NotificationManager.syncAll();
 			print_port();
 		};
 	}
@@ -4791,6 +4982,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		// 遠征出発.
 		func = function(json) { // 艦隊一覧を更新してcond表示する.
 			update_fdeck_list(json.api_data);
+			NotificationManager.syncAll();
 			print_port();
 		};
 	}
@@ -4926,6 +5118,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 					air_base.push(planes);
 				});
 			}
+			NotificationManager.syncAll();
 			print_mapinfo(uncleared, air_base);
 		};
 	}
@@ -4958,6 +5151,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		$is_boss = false;
 		make_debug_ship_names();
 		update_sortie_dn($battle_deck_id); if ($combined_flag) update_sortie_dn(2);
+		NotificationManager.syncAll();
 		func = on_next_cell;
 	}
 	else if (api_name == '/api_req_map/next') {
@@ -5040,6 +5234,7 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 		$battle_log = [];
 		make_debug_ship_names();
 		update_sortie_dn($battle_deck_id);
+		NotificationManager.syncAll();
 		func = on_battle;
 	}
 	else if (api_name == '/api_req_practice/midnight_battle') {

--- a/devtools.js
+++ b/devtools.js
@@ -27,7 +27,6 @@ var NotificationManager = {
 	enabled: false,
 	_cache: {},
 	_fleet_cond_timers: {},
-	_airbase_timers: {},
 	init: function() {
 		var self = this;
 		if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
@@ -93,13 +92,11 @@ var NotificationManager = {
 		}
 		this._cache = {};
 		this._fleet_cond_timers = {};
-		this._airbase_timers = {};
 	},
 	syncAll: function() {
 		if (!this.enabled) return;
 		this.syncMissionsAndCond();
 		this.syncNdocks();
-		this.syncAirBase();
 	},
 	syncMissionsAndCond: function() {
 		if (!$fdeck_list) return;
@@ -208,63 +205,6 @@ var NotificationManager = {
 				this.clearAlarm('ndock_' + dock_id);
 			}
 		}
-	},
-	syncAirBase: function() {
-		if (!$air_base || !Array.isArray($air_base)) return;
-		var self = this;
-		var nowTime = ($pcDateTime ? $pcDateTime.getTime() : Date.now());
-		$air_base.forEach(function(data) {
-			if (!data || !data.api_area_id || !data.api_rid) return;
-			var plane_info = data.api_plane_info;
-			var max_ab_cond = 1;
-			if (plane_info && Array.isArray(plane_info)) {
-				for (var j = 0; j < plane_info.length; j++) {
-					if (plane_info[j].api_state > 0 && plane_info[j].api_cond > max_ab_cond) {
-						max_ab_cond = plane_info[j].api_cond;
-					}
-				}
-			}
-			var ab_alarm_id = 'airbase_cond_' + data.api_area_id + '_' + data.api_rid;
-			var ab_name = get_maparea_name(data.api_area_id) + ' 第' + data.api_rid + '基地航空隊';
-			if (max_ab_cond >= 2) {
-				var cached = self._airbase_timers[ab_alarm_id];
-				// 休息(4)なら回復速度2倍（1段階あたり7.5分）、それ以外は1段階あたり15分
-				var stepMinutes = (data.api_action_kind === 4) ? 7.5 : 15;
-				var needSteps = (max_ab_cond === 3 ? 2 : 1);
-				var totalDuration = needSteps * stepMinutes * 60 * 1000;
-
-				if (cached) {
-					if (max_ab_cond > cached.cond) {
-						// 疲労悪化時は新しい目標時刻で再計算
-						var targetTime = nowTime + totalDuration;
-						self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
-						self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
-					} else if (cached.action_kind !== data.api_action_kind) {
-						// 行動種別変更時（休息への切り替え等）は再計算
-						var targetTime = nowTime + (needSteps * stepMinutes * 60 * 1000);
-						self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
-						self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
-					} else if (cached.when > nowTime) {
-						// 回復進行中または同一condでタイマー未満了：当初の目標時刻を維持（Timer Drift防止）
-						cached.cond = max_ab_cond;
-						self.setAlarm(ab_alarm_id, cached.when, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
-					} else {
-						// 満了後かつ疲労悪化なし：ゴースト再セットを防止
-						cached.cond = max_ab_cond;
-						cached.notified = true;
-						self.clearAlarm(ab_alarm_id);
-					}
-				} else {
-					// 新規タイマーセット
-					var targetTime = nowTime + totalDuration;
-					self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
-					self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
-				}
-			} else {
-				delete self._airbase_timers[ab_alarm_id];
-				self.clearAlarm(ab_alarm_id);
-			}
-		});
 	}
 };
 NotificationManager.init();
@@ -5186,68 +5126,6 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 			}
 			NotificationManager.syncAll();
 			print_mapinfo(uncleared, air_base);
-		};
-	}
-	else if (api_name == '/api_get_member/base_air_corps') {
-		// 基地航空隊一覧・状態取得.
-		func = function(json) {
-			if (json.api_data && Array.isArray(json.api_data)) {
-				if (!$air_base || !Array.isArray($air_base)) {
-					$air_base = [];
-				}
-				json.api_data.forEach(function(new_data) {
-					var found = false;
-					for (var i = 0; i < $air_base.length; i++) {
-						if ($air_base[i].api_area_id == new_data.api_area_id && $air_base[i].api_rid == new_data.api_rid) {
-							$air_base[i] = new_data;
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-						$air_base.push(new_data);
-					}
-				});
-				save_storage('air_base', $air_base);
-				NotificationManager.syncAll();
-			}
-		};
-	}
-	else if (api_name == '/api_req_air_base/set_action') {
-		// 基地航空隊行動変更 (待機, 出撃, 防空, 退避, 休息).
-		var params = decode_postdata_params(request.request.postData.params);
-		var area_id = params.api_area_id;
-		var base_id = params.api_base_id || params.api_rid;
-		var action_kind = parseInt(params.api_action_kind, 10);
-		func = function(json) {
-			if ($air_base && Array.isArray($air_base) && area_id && base_id) {
-				for (var i = 0; i < $air_base.length; i++) {
-					if ($air_base[i].api_area_id == area_id && $air_base[i].api_rid == base_id) {
-						$air_base[i].api_action_kind = action_kind;
-						break;
-					}
-				}
-				save_storage('air_base', $air_base);
-				NotificationManager.syncAll();
-			}
-		};
-	}
-	else if (api_name == '/api_req_air_base/supply') {
-		// 基地航空隊補給.
-		var params = decode_postdata_params(request.request.postData.params);
-		var area_id = params.api_area_id;
-		var base_id = params.api_base_id || params.api_rid;
-		func = function(json) {
-			if ($air_base && Array.isArray($air_base) && area_id && base_id && json.api_data && json.api_data.api_plane_info) {
-				for (var i = 0; i < $air_base.length; i++) {
-					if ($air_base[i].api_area_id == area_id && $air_base[i].api_rid == base_id) {
-						$air_base[i].api_plane_info = json.api_data.api_plane_info;
-						break;
-					}
-				}
-				save_storage('air_base', $air_base);
-				NotificationManager.syncAll();
-			}
 		};
 	}
 	else if (api_name == '/api_req_map/select_eventmap_rank') {

--- a/devtools.js
+++ b/devtools.js
@@ -186,15 +186,38 @@ var NotificationManager = {
 			var ab_name = get_maparea_name(data.api_area_id) + ' 第' + data.api_rid + '基地航空隊';
 			if (max_ab_cond >= 2) {
 				var cached = self._airbase_timers[ab_alarm_id];
-				var targetTime;
-				if (cached && cached.cond === max_ab_cond && cached.when > nowTime) {
-					targetTime = cached.when; // 既存の疲労回復予定時刻を維持（リセット防止）
+				// 休息(4)なら回復速度2倍（1段階あたり7.5分）、それ以外は1段階あたり15分
+				var stepMinutes = (data.api_action_kind === 4) ? 7.5 : 15;
+				var needSteps = (max_ab_cond === 3 ? 2 : 1);
+				var totalDuration = needSteps * stepMinutes * 60 * 1000;
+
+				if (cached) {
+					if (max_ab_cond > cached.cond) {
+						// 疲労悪化時は新しい目標時刻で再計算
+						var targetTime = nowTime + totalDuration;
+						self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
+						self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
+					} else if (cached.action_kind !== data.api_action_kind) {
+						// 行動種別変更時（休息への切り替え等）は再計算
+						var targetTime = nowTime + (needSteps * stepMinutes * 60 * 1000);
+						self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
+						self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
+					} else if (cached.when > nowTime) {
+						// 回復進行中または同一condでタイマー未満了：当初の目標時刻を維持（Timer Drift防止）
+						cached.cond = max_ab_cond;
+						self.setAlarm(ab_alarm_id, cached.when, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
+					} else {
+						// 満了後かつ疲労悪化なし：ゴースト再セットを防止
+						cached.cond = max_ab_cond;
+						cached.notified = true;
+						self.clearAlarm(ab_alarm_id);
+					}
 				} else {
-					var duration = (max_ab_cond === 3 ? 30 : 15) * 60 * 1000;
-					targetTime = nowTime + duration;
-					self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime };
+					// 新規タイマーセット
+					var targetTime = nowTime + totalDuration;
+					self._airbase_timers[ab_alarm_id] = { cond: max_ab_cond, when: targetTime, notified: false, action_kind: data.api_action_kind };
+					self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
 				}
-				self.setAlarm(ab_alarm_id, targetTime, '基地航空隊 疲労回復', ab_name + 'の疲労が回復しました。');
 			} else {
 				delete self._airbase_timers[ab_alarm_id];
 				self.clearAlarm(ab_alarm_id);
@@ -5120,6 +5143,68 @@ chrome.devtools.network.onRequestFinished.addListener(function (request) {
 			}
 			NotificationManager.syncAll();
 			print_mapinfo(uncleared, air_base);
+		};
+	}
+	else if (api_name == '/api_get_member/base_air_corps') {
+		// 基地航空隊一覧・状態取得.
+		func = function(json) {
+			if (json.api_data && Array.isArray(json.api_data)) {
+				if (!$air_base || !Array.isArray($air_base)) {
+					$air_base = [];
+				}
+				json.api_data.forEach(function(new_data) {
+					var found = false;
+					for (var i = 0; i < $air_base.length; i++) {
+						if ($air_base[i].api_area_id == new_data.api_area_id && $air_base[i].api_rid == new_data.api_rid) {
+							$air_base[i] = new_data;
+							found = true;
+							break;
+						}
+					}
+					if (!found) {
+						$air_base.push(new_data);
+					}
+				});
+				save_storage('air_base', $air_base);
+				NotificationManager.syncAll();
+			}
+		};
+	}
+	else if (api_name == '/api_req_air_base/set_action') {
+		// 基地航空隊行動変更 (待機, 出撃, 防空, 退避, 休息).
+		var params = decode_postdata_params(request.request.postData.params);
+		var area_id = params.api_area_id;
+		var base_id = params.api_base_id || params.api_rid;
+		var action_kind = parseInt(params.api_action_kind, 10);
+		func = function(json) {
+			if ($air_base && Array.isArray($air_base) && area_id && base_id) {
+				for (var i = 0; i < $air_base.length; i++) {
+					if ($air_base[i].api_area_id == area_id && $air_base[i].api_rid == base_id) {
+						$air_base[i].api_action_kind = action_kind;
+						break;
+					}
+				}
+				save_storage('air_base', $air_base);
+				NotificationManager.syncAll();
+			}
+		};
+	}
+	else if (api_name == '/api_req_air_base/supply') {
+		// 基地航空隊補給.
+		var params = decode_postdata_params(request.request.postData.params);
+		var area_id = params.api_area_id;
+		var base_id = params.api_base_id || params.api_rid;
+		func = function(json) {
+			if ($air_base && Array.isArray($air_base) && area_id && base_id && json.api_data && json.api_data.api_plane_info) {
+				for (var i = 0; i < $air_base.length; i++) {
+					if ($air_base[i].api_area_id == area_id && $air_base[i].api_rid == base_id) {
+						$air_base[i].api_plane_info = json.api_data.api_plane_info;
+						break;
+					}
+				}
+				save_storage('air_base', $air_base);
+				NotificationManager.syncAll();
+			}
 		};
 	}
 	else if (api_name == '/api_req_map/select_eventmap_rank') {

--- a/devtools.js
+++ b/devtools.js
@@ -77,7 +77,8 @@ var NotificationManager = {
 			if (mission_end > 0) {
 				var id = deck.api_mission[1];
 				var m_name = ($mst_mission && $mst_mission[id]) ? $mst_mission[id].api_name : ('遠征' + id);
-				this.setAlarm('mission_' + f_id, mission_end, '遠征帰投', '第' + f_id + '艦隊（' + m_name + '）が遠征から帰投しました。');
+				var alarm_time = (mission_end - 60 * 1000 > nowTime) ? (mission_end - 60 * 1000) : mission_end;
+				this.setAlarm('mission_' + f_id, alarm_time, '遠征帰投', '第' + f_id + '艦隊（' + m_name + '）が遠征から帰投しました。');
 				delete this._fleet_cond_timers[f_id];
 				this.clearAlarm('cond_' + f_id);
 			} else {
@@ -148,6 +149,7 @@ var NotificationManager = {
 	},
 	syncNdocks: function() {
 		var active_docks = {};
+		var nowTime = ($pcDateTime ? $pcDateTime.getTime() : Date.now());
 		if ($ndock_list) {
 			for (var ship_id in $ndock_list) {
 				var d = $ndock_list[ship_id];
@@ -161,7 +163,8 @@ var NotificationManager = {
 			if (d) {
 				var ship = ($ship_list && d.api_ship_id) ? $ship_list[d.api_ship_id] : null;
 				var ship_name_str = (ship && $mst_ship) ? ship_name(ship.ship_id) : '艦娘';
-				this.setAlarm('ndock_' + dock_id, d.api_complete_time, '入渠完了', '第' + dock_id + 'ドック（' + ship_name_str + '）の入渠が完了しました。');
+				var alarm_time = (d.api_complete_time - 60 * 1000 > nowTime) ? (d.api_complete_time - 60 * 1000) : d.api_complete_time;
+				this.setAlarm('ndock_' + dock_id, alarm_time, '入渠完了', '第' + dock_id + 'ドック（' + ship_name_str + '）の入渠が完了しました。');
 			} else {
 				this.clearAlarm('ndock_' + dock_id);
 			}

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,9 @@
 	},
 	"permissions": [
 		"storage",
-		"tabs"
+		"tabs",
+		"notifications",
+		"alarms"
 	],
 	"background": {
 		"service_worker": "background-wrapper.js"

--- a/style-yps.css
+++ b/style-yps.css
@@ -4,7 +4,7 @@
 .yps-body {
 	white-space: pre-wrap;
 	position: absolute;
-	top: 64px; /* game-header 40px + margin 20px */
+	top: 88px; /* game-header 40px + margin 20px + navi-3lines */
 	left: 1298px; /* game-header 1280px + padding 10px + margin 8px */
 }
 .yps-history {
@@ -13,6 +13,10 @@
 .yps-navi {
 	white-space: nowrap;
 	top: 8px; /* margin 8px */
+}
+#YPS_notification {
+	width: 80px;
+	text-align: center;
 }
 .yps-cliptext {
 	position: fixed;


### PR DESCRIPTION
## 背景・目的
KanColle-YPSの「余所見プレイ支援」において、ブラウザを最小化していたり別タブ・別ウィンドウで作業している際にも、艦隊の出撃準備が整ったタイミングを逃さず把握できるようにするため、デスクトップ通知機能を追加しました。

---

## 追加した機能
以下のイベント発生時に、OSのデスクトップ通知を表示します：

1. **遠征帰投通知**: 遠征艦隊が母港へ帰投した時（※ゲーム内仕様に合わせ、帰投可能となる1分前に通知）
2. **cond回復通知**: 艦隊内の全艦が cond 49 以上に自然回復した時（艦隊単位）
3. **入渠完了通知**: ドックでの修復が完了した時（※ゲーム内仕様に合わせ、修復完了となる1分前に通知、高速修復時はキャンセル）
4. **基地航空隊 疲労回復通知**: 航空隊全体が出撃可能（疲労全快）になった時（※基地画面オープン・札変更・補給パケットと同期、休息札時は短縮計算）
5. **通知クリック連動**: 通知をクリックした際、艦これのタブを最前面にフォーカス

---

## 実装の概要
既存の画面描画（Markdown生成）処理には影響を与えないよう、状態更新と連動する独立した通知管理を行っています。

- **`manifest.json`**:
  - `permissions` に `"notifications"` および `"alarms"` を追加
- **`background.js`**:
  - Service Worker にて `chrome.alarms` によるタイマー監視と `chrome.notifications` の通知発行・クリックイベントを処理
- **`devtools.js`**:
  - 画面描画とは独立した `NotificationManager` を追加し、母港・出撃・編成・入渠・基地航空隊などの通信API受信時のデータ更新に合わせてアラームを同期

---

## 動作確認
実機（Chrome / Windows）および自動テストにて、以下の動作を確認済みです：
- 遠征帰投時にデスクトップ通知が正常に届くこと（終了1分前通知を含む）
- 入渠完了時にデスクトップ通知が正常に届くこと（終了1分前通知を含む）
- 潜水艦での出撃・帰投後、母港待機により cond 回復通知が届くこと
- 基地航空隊の疲労回復通知が届くこと（休息札時の短縮計算およびタイマー満了後のゴースト再セット防止を含む）
- デスクトップ通知をクリックした際に艦これタブがアクティブになること
